### PR TITLE
Example of slow consumer group rejoining on app restart

### DIFF
--- a/src/main/java/com/github/big/andy/coates/kafka/App.java
+++ b/src/main/java/com/github/big/andy/coates/kafka/App.java
@@ -42,7 +42,10 @@ public final class App implements AutoCloseable {
     }
 
     public void close() {
-        streams.close();
+        final KafkaStreams.CloseOptions closeOptions = new KafkaStreams.CloseOptions();
+        // Uncommenting this has no affect:
+        // closeOptions.leaveGroup(true);
+        streams.close(closeOptions);
     }
 
     private static Properties properties(


### PR DESCRIPTION
** DO NOT MERGE: Example only **

Updated the code & test to demonstrate issue where restarting the KafkaStreams app sees the app pause for 45+ seconds on startup, while it waits to re-join the consumer group.

Looking at the Kafka broker logs in Docker, the group doesn't rebalance and allow the restarted app to start until the old consumer times out, i.e. `session.timeout.ms` is exceeded, which defaults to 30 seconds.

Setting the `leaveGroup` option on the `CloseOptions` has no affect, as this only comes into effect when using static member assignment via `group.instance.id`.

The open question is: how can KStreams be configured to allow the app to be shutdown in such as way that it can quickly rejoin the group on restart?

Ideally, if the app can restart within `group.initial.rebalance.delay.ms`, there should be _at most_ one rebalance as the new member joins.